### PR TITLE
Fix buggy regex

### DIFF
--- a/tools/FsBlogLib/BlogPosts.fs
+++ b/tools/FsBlogLib/BlogPosts.fs
@@ -32,7 +32,7 @@ module BlogPosts =
   let scriptHeaderRegex = 
     Regex("^\(\*\@(?<header>[^\*]*)\*\)(?<content>.*)$", RegexOptions.Singleline)
   let razorHeaderRegex = 
-    Regex("^\@{(?<header>[^\*]*)}(?<content>.*)$", RegexOptions.Singleline)
+    Regex("^\@{(?<header>[^}]*)}(?<content>.*)$", RegexOptions.Singleline)
 
   /// An FSX file must start with a header (*@ ... *) which is removed 
   /// before Literate processing (and then added back as @{ ... }


### PR DESCRIPTION
This is hacky part anyway - but when you have a `.md` file that contains Razor header `@{ Layout="..." etc. }` then we only want the header (and not all content until some `}` that appears later). This should be replaced with a proper parser though.
