### PR TITLE
Update FsFormatting and fix build.

### DIFF
--- a/layouts/default.cshtml
+++ b/layouts/default.cshtml
@@ -18,12 +18,14 @@
     <!-- FSharp.Formatting Styles --> 
   	<link rel="stylesheet" type="text/css" media="screen" href="@Model.Root/fsharp.formatting/tooltips.css" /> 
   	<script type="text/javascript" src="@Model.Root/fsharp.formatting/tooltips.js"></script>
+    <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
   </head>
   <body>
   	<div class="wrapper">
 	  <header>
 	  	  <a href="@Model.Root/index.html" class="falseheader">FsBlog</a>
         <p>Blog aware, static site generation using F#.</p>
+        
         <p class="view"><a href="https://github.com/saxonmatt/FsBlog">View the Project on GitHub</a></p>
         <ul>
           <li><a href="https://github.com/saxonmatt/FsBlog">View On <strong>GitHub</strong></a></li>

--- a/tools/FsBlogLib/AssemblyInfo.fs
+++ b/tools/FsBlogLib/AssemblyInfo.fs
@@ -6,7 +6,7 @@ open System.Reflection
 [<assembly: AssemblyDescriptionAttribute("Blog aware, static site generation using F#.")>]
 [<assembly: AssemblyVersionAttribute("0.4.1")>]
 [<assembly: AssemblyFileVersionAttribute("0.4.1")>]
-()
+do ()
 
 module internal AssemblyVersionInformation =
     let [<Literal>] Version = "0.4.1"

--- a/tools/FsBlogLib/FsBlogLib.fsproj
+++ b/tools/FsBlogLib/FsBlogLib.fsproj
@@ -20,28 +20,30 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
-    <OutputPath>bin\Debug\</OutputPath>
+    <OutputPath>..\..\bin\FsBlogLib</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Debug\FsBlogLib.XML</DocumentationFile>
+    <DocumentationFile>
+    </DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
-    <OutputPath>bin\Release\</OutputPath>
+    <OutputPath>..\..\bin\FsBlogLib</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <WarningLevel>3</WarningLevel>
-    <DocumentationFile>bin\Release\FsBlogLib.XML</DocumentationFile>
+    <DocumentationFile>
+    </DocumentationFile>
   </PropertyGroup>
   <PropertyGroup>
     <MinimumVisualStudioVersion Condition="'$(MinimumVisualStudioVersion)' == ''">11</MinimumVisualStudioVersion>
   </PropertyGroup>
   <PropertyGroup>
-     <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
+    <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(VisualStudioVersion)' == '11.0' Or $(OS) != 'Windows_NT'">
-     <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
+    <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
   </PropertyGroup>
   <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
   <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
@@ -56,30 +58,33 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="FSharp.CodeFormat">
-      <HintPath>..\..\packages\FSharp.Formatting.2.1.6\lib\net40\FSharp.CodeFormat.dll</HintPath>
+      <HintPath>..\..\packages\FSharp.Formatting.2.4.0\lib\net40\FSharp.CodeFormat.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="FSharp.Compiler.Service">
+      <HintPath>..\..\packages\FSharp.Compiler.Service.0.0.20\lib\net40\FSharp.Compiler.Service.dll</HintPath>
+    </Reference>
     <Reference Include="FSharp.CompilerBinding">
-      <HintPath>..\..\packages\FSharp.Formatting.2.1.6\lib\net40\FSharp.CompilerBinding.dll</HintPath>
+      <HintPath>..\..\packages\FSharp.Formatting.2.4.0\lib\net40\FSharp.CompilerBinding.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>True</Private>
     </Reference>
     <Reference Include="FSharp.Literate">
-      <HintPath>..\..\packages\FSharp.Formatting.2.1.6\lib\net40\FSharp.Literate.dll</HintPath>
+      <HintPath>..\..\packages\FSharp.Formatting.2.4.0\lib\net40\FSharp.Literate.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FSharp.Markdown">
-      <HintPath>..\..\packages\FSharp.Formatting.2.1.6\lib\net40\FSharp.Markdown.dll</HintPath>
+      <HintPath>..\..\packages\FSharp.Formatting.2.4.0\lib\net40\FSharp.Markdown.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FSharp.MetadataFormat">
-      <HintPath>..\..\packages\FSharp.Formatting.2.1.6\lib\net40\FSharp.MetadataFormat.dll</HintPath>
+      <HintPath>..\..\packages\FSharp.Formatting.2.4.0\lib\net40\FSharp.MetadataFormat.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="FSharp.PowerPack.Metadata">
-      <HintPath>..\..\packages\FSharp.Formatting.2.1.6\lib\net40\FSharp.PowerPack.Metadata.dll</HintPath>
+      <HintPath>..\..\packages\FSharp.Formatting.2.4.0\lib\net40\FSharp.PowerPack.Metadata.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="mscorlib" />
@@ -92,6 +97,7 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Numerics" />
     <Reference Include="System.Web.Razor, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
+      <HintPath>..\..\packages\Microsoft.AspNet.Razor.2.0.30506.0\lib\net40\System.Web.Razor.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System.Xml" />

--- a/tools/FsBlogLib/packages.config
+++ b/tools/FsBlogLib/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FSharp.Formatting" version="2.1.6" targetFramework="net45" />
+  <package id="FSharp.Formatting" version="2.4.0" targetFramework="net45" />
+  <package id="FSharp.Compiler.Service" version="0.0.20" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net45" />
   <package id="RazorEngine" version="3.3.0" targetFramework="net45" />
 </packages>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FSharp.Formatting" version="2.1.6" targetFramework="net45" />
+  <package id="FSharp.Formatting" version="2.4.0" targetFramework="net45" />
+  <package id="FSharp.Compiler.Service" version="0.0.20" targetFramework="net45" />
   <package id="Microsoft.AspNet.Razor" version="2.0.30506.0" targetFramework="net45" />
   <package id="RazorEngine" version="3.3.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Update F# Formatting to the latest version which supports latex and more.
Fix build from Visual Studio (to put binaries in bin/FsBlogLib) and update
fsproj file to include HintPath for Razor.
