### PR TITLE
Updated FsBlog.nuspec so that Paket will be included in the NuGet package.

### DIFF
--- a/FsBlog.nuspec
+++ b/FsBlog.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
     <metadata>
         <id>FsBlog</id>
-        <version>1.0.1-alpha</version>
+        <version>1.0.2-alpha</version>
         <authors>Matt Ball, Dave Thomas,Tomas Petricek</authors>
         <owners>Matt Ball, Dave Thomas,Tomas Petricek</owners>
         <projectUrl>https://github.com/fsprojects/FsBlog</projectUrl>
@@ -28,6 +28,7 @@ This set of tools have been pulled together using some of the following communit
         </dependencies>-->
     </metadata>
   <files>
+    <file src="packages\Paket\tools\paket.exe" target="content\.paket"/>
     <file src="**\*.*" exclude="**\*.suo;**\*.sln;**\build.*;**\.git*;**\.git\**\*.*;packages\**\*.*;tools\**\*.*;tests\**\*.*;deploy\**\*.*;output\**\*.*;**\bin\**\*.*;**\obj\**\*.*" target="content"/>
     <file src="tools\empty-template.html" target="content\tools"/>
     <file src="bin\**\*.dll" exclude="**\xunit*.dll" target="content\bin"/>

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -6,3 +6,4 @@ nuget FsUnit.xUnit
 nuget xunit.runners
 nuget NuGet.CommandLine
 nuget FAKE
+nuget paket

--- a/paket.lock
+++ b/paket.lock
@@ -18,3 +18,4 @@ NUGET
       Microsoft.AspNet.Razor (>= 2.0.30506.0)
     xunit (1.9.2)
     xunit.runners (1.9.2)
+    Paket (0.26.5)


### PR DESCRIPTION
As it stands right now, running ``nuget pack FsBlog.nuspec`` results in a NuGet
package which does not include Paket. Running ``fake`` from the NuGet package
fails because there is no .paket directory with paket.exe or
paket.bootstrapper.exe.

Due to a bug (feature?) of ``nuget pack``, copying of files or directories which
begin with a dot is troublesome. I added Paket as a dependency so that I could
copy it from the packages directory instead.

Also updated the NuGet version number. Perhaps it is time to upload a new
package to nuget.org?