### PR TITLE
Use relative protocol in template

### DIFF
--- a/content/layouts/default.cshtml
+++ b/content/layouts/default.cshtml
@@ -15,17 +15,17 @@
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
-    <!-- FSharp.Formatting Styles --> 
-  	<link rel="stylesheet" type="text/css" media="screen" href="@Model.Root/fsharp.formatting/tooltips.css" /> 
+    <!-- FSharp.Formatting Styles -->
+  	<link rel="stylesheet" type="text/css" media="screen" href="@Model.Root/fsharp.formatting/tooltips.css" />
   	<script type="text/javascript" src="@Model.Root/fsharp.formatting/tooltips.js"></script>
-    <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
   </head>
   <body>
   	<div class="wrapper">
 	  <header>
 	  	  <a href="@Model.Root/index.html" class="falseheader">FsBlog</a>
         <p>Blog aware, static site generation using F#.</p>
-        
+
         <p class="view"><a href="https://github.com/saxonmatt/FsBlog">View the Project on GitHub</a></p>
         <ul>
           <li><a href="https://github.com/saxonmatt/FsBlog">View On <strong>GitHub</strong></a></li>

--- a/themes/default/layouts/default.cshtml
+++ b/themes/default/layouts/default.cshtml
@@ -15,17 +15,17 @@
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->
-    <!-- FSharp.Formatting Styles --> 
-  	<link rel="stylesheet" type="text/css" media="screen" href="@Model.Root/fsharp.formatting/tooltips.css" /> 
+    <!-- FSharp.Formatting Styles -->
+  	<link rel="stylesheet" type="text/css" media="screen" href="@Model.Root/fsharp.formatting/tooltips.css" />
   	<script type="text/javascript" src="@Model.Root/fsharp.formatting/tooltips.js"></script>
-    <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+    <script type="text/javascript" src="//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
   </head>
   <body>
   	<div class="wrapper">
 	  <header>
 	  	  <a href="@Model.Root/index.html" class="falseheader">FsBlog</a>
         <p>Blog aware, static site generation using F#.</p>
-        
+
         <p class="view"><a href="https://github.com/saxonmatt/FsBlog">View the Project on GitHub</a></p>
         <ul>
           <li><a href="https://github.com/saxonmatt/FsBlog">View On <strong>GitHub</strong></a></li>


### PR DESCRIPTION
 - When referencing the mathjax CDN, use a relative protocol to avoid warnings
   when delivered on HTTPS.
 - Atom normalisation of whitespace.