### PR TITLE
Fix for case-sensitive filesystems

### DIFF
--- a/fsblog.fsx
+++ b/fsblog.fsx
@@ -15,7 +15,7 @@ and tasks that operate with the static site generation.
 #r "RazorEngine.dll"
 #r "FsBlogLib.dll"
 #r "FSharp.Configuration.dll"
-#r "suave.dll"
+#r "Suave.dll"
 
 open Fake
 open Fake.Git


### PR DESCRIPTION
Fixes incorrect naming of `Suave.dll`.